### PR TITLE
chore: add .nvmrc (lts/krypton)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/krypton


### PR DESCRIPTION
Dodaje `.nvmrc` z `lts/krypton`.

default.

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.